### PR TITLE
Rename html* to HTML* module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Actions Status](https://github.com/mirego/html_test_helpers/workflows/CI/badge.svg?branch%3Amaster)](https://github.com/mirego/html_test_helpers/actions)
 
-# HtmlTestHelpers
+# HTMLTestHelpers
 
 Functions helpers for unit testing.
 Validate HTML tag identified by data-testid attributes
@@ -79,7 +79,7 @@ assert_html_text(raw_html, "paragraph-id", "First paragraph content")
 # left:  "First paragraph content"
 # right: "wrong content"
 
-#     (html_test_helpers) lib/html_test_helpers.ex:106: HtmlTestHelpers.assert_html_text/3
+#     (html_test_helpers) lib/html_test_helpers.ex:106: HTMLTestHelpers.assert_html_text/3
 ```
 
 Also if you just need the value identified by `data-testid` attribute you can use :

--- a/lib/html_test_helpers.ex
+++ b/lib/html_test_helpers.ex
@@ -1,4 +1,4 @@
-defmodule HtmlTestHelpers do
+defmodule HTMLTestHelpers do
   @moduledoc """
   Functions helpers for unit testing.
   Validate HTML tag identified by data-testid attributes
@@ -77,7 +77,7 @@ defmodule HtmlTestHelpers do
   # left:  "First paragraph content"
   # right: "wrong content"
 
-  #     (html_test_helpers) lib/html_test_helpers.ex:106: HtmlTestHelpers.assert_html_text/3
+  #     (html_test_helpers) lib/html_test_helpers.ex:106: HTMLTestHelpers.assert_html_text/3
   ```
 
   Also if you just need the value identified by `data-testid` attribute you can use :

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule HtmlTestHelpers.MixProject do
+defmodule HTMLTestHelpers.MixProject do
   use Mix.Project
 
   def project do

--- a/test/html_test_helpers_test.exs
+++ b/test/html_test_helpers_test.exs
@@ -1,8 +1,8 @@
-defmodule HtmlTestHelpersTest do
+defmodule HTMLTestHelpersTest do
   use ExUnit.Case, async: true
 
   alias ExUnit.AssertionError
-  import HtmlTestHelpers
+  import HTMLTestHelpers
 
   setup do
     raw_html = """


### PR DESCRIPTION
## 📖 Description and reason

Rename `HtmlTestHelpers` module name to `HTMLTestHelpers`