### PR TITLE
Improve CI Workflow and add Publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Run Hex Publish test
         run: mix hex.publish --dry-run
         env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          HEX_API_KEY: DRYRUN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,24 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elixir-version: [1.12.x, 1.11.x, 1.10.x, 1.9.x]
+        include:
+          - elixir-version: 1.12.x
+            otp-version: 24.x
+          - elixir-version: 1.11.x
+            otp-version: 23.x
+          - elixir-version: 1.10.x
+            otp-version: 22.x
+          - elixir-version: 1.9.x
+            otp-version: 21.x
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
-          otp-version: 22.2
-          elixir-version: 1.9.4
+          otp-version: ${{ matrix.otp-version }}
+          elixir-version: ${{ matrix.elixir-version }}
       - name: Install Elixir Dependencies
         run: mix deps.get
       - name: Lint
@@ -19,3 +31,7 @@ jobs:
           mix credo --strict
       - name: Run Tests
         run: mix test
+      - name: Run Hex Publish test
+        run: mix hex.publish --dry-run
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: 24.x
+          elixir-version: 1.12.x
+      - run: mix deps.get
+      - run: mix hex.publish --yes


### PR DESCRIPTION
## 📖 Description and reason

A few maintenance tasks in our GitHub Actions workflows.

## 👷 Work done

#### Tasks

- [x] Update OTP/Elixir version matrix to test against
- [x] Use the official erlef/setup-beam action
- [x] Add mix hex.publish --dry-run as a CI step
- [x] Add a new Publish workflow to automatically publish tags to hex.pm!

## 🦀 Dispatch

`#dispatch/elixir`
