### PR TITLE
Add assert_html_element_exist and assert_html_element_does_not_exist

### DIFF
--- a/lib/html_test_helpers.ex
+++ b/lib/html_test_helpers.ex
@@ -32,6 +32,8 @@ defmodule HTMLTestHelpers do
   |> assert_html_attribute("test-link-id", "href", "/expected/link")
   |> assert_html_attribute("test-link-id", "class", :contains, "my-link-class")
   |> assert_html_attribute("test-footer-testid", "class", :equals, "footer small")
+  |> assert_html_element_exist("test-li-id-1")
+  |> assert_html_element_does_not_exist("test-li-id-5")
   # =>
   # [{"html", [],
   #   [
@@ -209,6 +211,48 @@ defmodule HTMLTestHelpers do
     end
 
     html
+  end
+
+  @spec assert_html_element_exist(html(), String.t()) :: html_document()
+  def assert_html_element_exist(html, data_test_id) when is_list(html) do
+    element = Floki.find(html, "[data-testid=#{data_test_id}]")
+
+    if Enum.empty?(element) do
+      error_args = [
+        message: "Expected an element with data-testid=`#{data_test_id}` but none was found\n"
+      ]
+
+      raise ExUnit.AssertionError, error_args
+    end
+
+    html
+  end
+
+  def assert_html_element_exist(raw_html, data_test_id) do
+    {:ok, document} = Floki.parse_document(raw_html)
+
+    assert_html_element_exist(document, data_test_id)
+  end
+
+  @spec assert_html_element_does_not_exist(html(), String.t()) :: html_document()
+  def assert_html_element_does_not_exist(html, data_test_id) when is_list(html) do
+    element = Floki.find(html, "[data-testid=#{data_test_id}]")
+
+    unless Enum.empty?(element) do
+      error_args = [
+        message: "Expected no element with data-testid=`#{data_test_id}` but one was found\n"
+      ]
+
+      raise ExUnit.AssertionError, error_args
+    end
+
+    html
+  end
+
+  def assert_html_element_does_not_exist(raw_html, data_test_id) do
+    {:ok, document} = Floki.parse_document(raw_html)
+
+    assert_html_element_does_not_exist(document, data_test_id)
   end
 
   defp check_values_valid?(:contains, attribute_values, expected_attribute_values) do

--- a/lib/html_test_helpers.ex
+++ b/lib/html_test_helpers.ex
@@ -32,8 +32,8 @@ defmodule HTMLTestHelpers do
   |> assert_html_attribute("test-link-id", "href", "/expected/link")
   |> assert_html_attribute("test-link-id", "class", :contains, "my-link-class")
   |> assert_html_attribute("test-footer-testid", "class", :equals, "footer small")
-  |> assert_html_element_exist("test-li-id-1")
-  |> assert_html_element_does_not_exist("test-li-id-5")
+  |> assert_html_element_exists("test-li-id-1")
+  |> refute_html_element_exists("test-li-id-5")
   # =>
   # [{"html", [],
   #   [
@@ -213,8 +213,8 @@ defmodule HTMLTestHelpers do
     html
   end
 
-  @spec assert_html_element_exist(html(), String.t()) :: html_document()
-  def assert_html_element_exist(html, data_test_id) when is_list(html) do
+  @spec assert_html_element_exists(html(), String.t()) :: html_document()
+  def assert_html_element_exists(html, data_test_id) when is_list(html) do
     element = Floki.find(html, "[data-testid=#{data_test_id}]")
 
     if Enum.empty?(element) do
@@ -228,14 +228,14 @@ defmodule HTMLTestHelpers do
     html
   end
 
-  def assert_html_element_exist(raw_html, data_test_id) do
+  def assert_html_element_exists(raw_html, data_test_id) do
     {:ok, document} = Floki.parse_document(raw_html)
 
-    assert_html_element_exist(document, data_test_id)
+    assert_html_element_exists(document, data_test_id)
   end
 
-  @spec assert_html_element_does_not_exist(html(), String.t()) :: html_document()
-  def assert_html_element_does_not_exist(html, data_test_id) when is_list(html) do
+  @spec refute_html_element_exists(html(), String.t()) :: html_document()
+  def refute_html_element_exists(html, data_test_id) when is_list(html) do
     element = Floki.find(html, "[data-testid=#{data_test_id}]")
 
     unless Enum.empty?(element) do
@@ -249,10 +249,10 @@ defmodule HTMLTestHelpers do
     html
   end
 
-  def assert_html_element_does_not_exist(raw_html, data_test_id) do
+  def refute_html_element_exists(raw_html, data_test_id) do
     {:ok, document} = Floki.parse_document(raw_html)
 
-    assert_html_element_does_not_exist(document, data_test_id)
+    refute_html_element_exists(document, data_test_id)
   end
 
   defp check_values_valid?(:contains, attribute_values, expected_attribute_values) do

--- a/test/html_test_helpers_test.exs
+++ b/test/html_test_helpers_test.exs
@@ -188,39 +188,39 @@ defmodule HTMLTestHelpersTest do
     end
   end
 
-  describe "assert_html_element_exist" do
+  describe "assert_html_element_exists" do
     test "with raw html and test_id id is found", %{raw_html: raw_html} do
-      assert_html_element_exist(raw_html, "headline-1")
+      assert_html_element_exists(raw_html, "headline-1")
     end
 
     test "with raw html and test_id is not found", %{raw_html: raw_html} do
       assert_raise AssertionError,
                    ~r/Expected an element with data-testid=`headline-5` but none was found/,
                    fn ->
-                     assert_html_element_exist(raw_html, "headline-5")
+                     assert_html_element_exists(raw_html, "headline-5")
                    end
     end
 
     test "with html structure and id is found", %{html_structure: html_structure} do
-      assert_html_element_exist(html_structure, "headline-1")
+      assert_html_element_exists(html_structure, "headline-1")
     end
   end
 
-  describe "assert_html_element_does_not_exist" do
+  describe "refute_html_element_exists" do
     test "with raw html and test_id id is found", %{raw_html: raw_html} do
       assert_raise AssertionError,
                    ~r/Expected no element with data-testid=`headline-1` but one was found/,
                    fn ->
-                     assert_html_element_does_not_exist(raw_html, "headline-1")
+                    refute_html_element_exists(raw_html, "headline-1")
                    end
     end
 
     test "with raw html and test_id is not found", %{raw_html: raw_html} do
-      assert_html_element_does_not_exist(raw_html, "headline-5")
+      refute_html_element_exists(raw_html, "headline-5")
     end
 
     test "with html structure and id is not found", %{html_structure: html_structure} do
-      assert_html_element_does_not_exist(html_structure, "headline-5")
+      refute_html_element_exists(html_structure, "headline-5")
     end
   end
 end

--- a/test/html_test_helpers_test.exs
+++ b/test/html_test_helpers_test.exs
@@ -187,4 +187,40 @@ defmodule HTMLTestHelpersTest do
       assert html_attributes(html_structure, "headline", "href") === []
     end
   end
+
+  describe "assert_html_element_exist" do
+    test "with raw html and test_id id is found", %{raw_html: raw_html} do
+      assert_html_element_exist(raw_html, "headline-1")
+    end
+
+    test "with raw html and test_id is not found", %{raw_html: raw_html} do
+      assert_raise AssertionError,
+                   ~r/Expected an element with data-testid=`headline-5` but none was found/,
+                   fn ->
+                     assert_html_element_exist(raw_html, "headline-5")
+                   end
+    end
+
+    test "with html structure and id is found", %{html_structure: html_structure} do
+      assert_html_element_exist(html_structure, "headline-1")
+    end
+  end
+
+  describe "assert_html_element_does_not_exist" do
+    test "with raw html and test_id id is found", %{raw_html: raw_html} do
+      assert_raise AssertionError,
+                   ~r/Expected no element with data-testid=`headline-1` but one was found/,
+                   fn ->
+                     assert_html_element_does_not_exist(raw_html, "headline-1")
+                   end
+    end
+
+    test "with raw html and test_id is not found", %{raw_html: raw_html} do
+      assert_html_element_does_not_exist(raw_html, "headline-5")
+    end
+
+    test "with html structure and id is not found", %{html_structure: html_structure} do
+      assert_html_element_does_not_exist(html_structure, "headline-5")
+    end
+  end
 end


### PR DESCRIPTION
Add two new helpers to assert that an element exist or doesn't exist in the page

## 📖 Description and reason

These helpers will make it easier to check if something is present in the page. This would be useful when we show or hide an element in the page and we want to assert that it's either present or absent.

## 🦀 Dispatch

`#dispatch/elixir`
