### PR TITLE
Add trim option for function assert_html_text

### DIFF
--- a/lib/html_test_helpers.ex
+++ b/lib/html_test_helpers.ex
@@ -100,17 +100,20 @@ defmodule HTMLTestHelpers do
   @type html_document :: [any()]
   @type html_raw :: String.t()
 
+  def assert_html_text(raw, data_test_id, expected_value, options \\ [trim: true])
+
   @spec assert_html_text(html(), String.t(), String.t()) :: html_document()
-  def assert_html_text(raw, data_test_id, expected_value) when is_binary(raw) do
+  def assert_html_text(raw, data_test_id, expected_value, options) when is_binary(raw) do
     {:ok, document} = Floki.parse_document(raw)
-    assert_html_text(document, data_test_id, expected_value)
+    assert_html_text(document, data_test_id, expected_value, options)
   end
 
-  def assert_html_text(html, data_test_id, expected_value) when is_list(html) do
+  def assert_html_text(html, data_test_id, expected_value, options) when is_list(html) do
     text_value =
       html
       |> Floki.find("[data-testid=#{data_test_id}]")
       |> Floki.text()
+      |> apply_options(options)
 
     text_expected_value = to_string(expected_value)
 
@@ -263,4 +266,9 @@ defmodule HTMLTestHelpers do
     length(expected_attribute_values) === length(attribute_values) &&
       expected_attribute_values -- attribute_values === []
   end
+
+  defp apply_options(text, options), do: Enum.reduce(options, text, &handle_options/2)
+
+  defp handle_options({:trim, true}, text), do: String.trim(text)
+  defp handle_options(_, text), do: text
 end

--- a/test/html_test_helpers_test.exs
+++ b/test/html_test_helpers_test.exs
@@ -11,6 +11,7 @@ defmodule HTMLTestHelpersTest do
       <body>
         <section id="content">
           <h1 data-testid="h1-id" class="title">Title</h1>
+          <h2 data-testid="h2-id" class="subtitle">\nSubtitle\n</h2>
           <p data-testid="headline-1" class="span-headline-1 first-span">First paragraph</p>
           <p data-testid="headline-2" class="span-headline-2">Second paragraph</p>
         </section>
@@ -26,6 +27,7 @@ defmodule HTMLTestHelpersTest do
             {"section", [{"id", "content"}],
              [
                {"h1", [{"data-testid", "h1-id"}, {"class", "title"}], ["Title"]},
+               {"h2", [{"data-testid", "h2-id"}, {"class", "subtitle"}], ["\nSubtitle\n"]},
                {"p", [{"data-testid", "headline-1"}, {"class", "span-headline-1 first-span"}],
                 ["First paragraph"]},
                {"p", [{"data-testid", "headline-2"}, {"class", "span-headline-2"}],
@@ -41,6 +43,19 @@ defmodule HTMLTestHelpersTest do
   describe "assert_html_text" do
     test "with raw html, pass when text is found", %{raw_html: raw_html} do
       assert_html_text(raw_html, "h1-id", "Title")
+    end
+
+    test "with raw html contains new lines, pass when text is trimmed (default behaviour)", %{raw_html: raw_html} do
+      assert_html_text(raw_html, "h2-id", "Subtitle")
+    end
+
+    test "with raw html contains new lines, raise when text is not trimmed", %{raw_html: raw_html} do
+      assert_raise AssertionError,
+                   ~r/Value identified by data-testid\[h2-id\] is not as expected/,
+                   fn ->
+                    assert_html_text(raw_html, "h2-id", "Subtitle", trim: false)
+                   end
+
     end
 
     test "with raw html, raise when text is not found", %{raw_html: raw_html} do


### PR DESCRIPTION
## 📖 Description and reason

We add options parameter for `assert_html_text`. By default we consider we want to validate content without any spaces before or after content.

If validation of spaces is important, we can use 
```elixir 
assert_html_text(raw_html, data_test_id, expected_value, trim: false)
```

## 🦀 Dispatch

`#dispatch/elixir`
